### PR TITLE
Refactor centrifugal factor and improve vehicle dynamics calculations

### DIFF
--- a/src/constants/physics.js
+++ b/src/constants/physics.js
@@ -34,7 +34,7 @@ export const MAX_STEER_HEADING = 0.22;
 
 export const HEADING_ALIGNMENT_RATE = 0.25;
 
-export const CENTRIFUGAL_FACTOR = 0.004;
+export const CENTRIFUGAL_FACTOR = 0.0;
 
 export const VISUAL_HEADING_LERP = 0.25;
 

--- a/src/constants/physics.js
+++ b/src/constants/physics.js
@@ -34,7 +34,7 @@ export const MAX_STEER_HEADING = 0.22;
 
 export const HEADING_ALIGNMENT_RATE = 0.25;
 
-export const CENTRIFUGAL_FACTOR = 0.0;
+export const CENTRIFUGAL_FACTOR = 0.005;
 
 export const VISUAL_HEADING_LERP = 0.25;
 

--- a/src/systems/physics/lateral.js
+++ b/src/systems/physics/lateral.js
@@ -37,9 +37,9 @@ function updateHeadingAndLateral(
 
   const vxSteer = vz * Math.sin(theta);
   const vxCentrifugal = curvature * vz * CENTRIFUGAL_FACTOR;
-  const x = (gameState.lateralOffset || 0) + (vxSteer + vxCentrifugal) * dt;
+  const x = (gameState.lateralOffset || 0) + (vxSteer - vxCentrifugal) * dt;
 
-  return { x, vx: vxSteer + vxCentrifugal };
+  return { x, vx: vxSteer - vxCentrifugal };
 }
 
 function applyOffTrackPenalties(gameState, x, vz, surfaceType, dt) {


### PR DESCRIPTION
This pull request makes small but important adjustments to the vehicle lateral physics calculations to improve simulation accuracy and realism.

Physics tuning:

* Increased the `CENTRIFUGAL_FACTOR` constant in `src/constants/physics.js` from 0.004 to 0.005 to slightly amplify the effect of centrifugal force in the simulation.
* Corrected the application of centrifugal force in `updateHeadingAndLateral` in `src/systems/physics/lateral.js` by subtracting, rather than adding, the centrifugal component from the lateral velocity and position calculations.