### PR TITLE
Adjust steering and braking parameters for improved control

### DIFF
--- a/src/constants/input.js
+++ b/src/constants/input.js
@@ -47,5 +47,5 @@ export const PREVENT_DEFAULT_KEYS = [
 ];
 
 export const STEER_DEADZONE_DEG = 3;
-export const STEER_MAX_TILT_DEG = 35;
+export const STEER_MAX_TILT_DEG = 22;
 export const STEER_RATE = 0.12;

--- a/src/constants/physics.js
+++ b/src/constants/physics.js
@@ -7,9 +7,9 @@ export const VZ_DRAG_MODE_Z = 0.993;
 export const VZ_MAX_MODE_X = 23;
 export const VZ_MAX_MODE_Z = 19;
 
-export const MANUAL_BRAKE_DECEL = 0.82;
+export const MANUAL_BRAKE_DECEL = 0.88;
 export const MANUAL_BRAKE_DECEL_SOFT = 0.97;
-export const BRAKE_RAMP_RATE = 0.45;
+export const BRAKE_RAMP_RATE = 0.25;
 
 export const BOOST_BASE_GAIN = 16;
 


### PR DESCRIPTION
This pull request updates several tuning constants related to steering and braking to adjust the vehicle's handling characteristics. The main changes reduce the maximum steering tilt and make braking more responsive and aggressive.

Physics and input tuning:

* Reduced `STEER_MAX_TILT_DEG` from 35 to 22 degrees in `src/constants/input.js`, limiting the maximum steering angle for more controlled steering.
* Increased `MANUAL_BRAKE_DECEL` from 0.82 to 0.88 and decreased `BRAKE_RAMP_RATE` from 0.45 to 0.25 in `src/constants/physics.js`, making manual braking stronger and the brake response quicker.