### PR TITLE
Dynamically calculate effective page size for leaderboard

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -251,9 +251,20 @@ class Game {
           this._setScreen(SCREENS.LEADERBOARD);
         },
       changeLeaderboardPage: (delta) => {
-        
         if (!this.gameState) return;
-        const PAGE_SIZE = 10;
+        // Replica o mesmo cálculo de effectivePageSize do screen-renderer
+        const isPortrait = window.innerHeight > window.innerWidth;
+        const h = window.innerHeight;
+        const w = window.innerWidth;
+        const pad = Math.max(20, w * 0.05);
+        const titleSz = Math.max(18, Math.min(36, w * 0.06));
+        const ctrlBtnH = isPortrait ? 24 : 18;
+        const topY = pad + titleSz + ctrlBtnH + 18;
+        const availH = h - topY - 40 - pad;
+        const minRowH = isPortrait ? 22 : 20;
+        const maxRowH = isPortrait ? 44 : 40;
+        const rowH = Math.max(minRowH, Math.min(maxRowH, Math.round(availH / 8)));
+        const PAGE_SIZE = Math.max(1, Math.floor(availH / (rowH + 4)));
         const total = (this.gameState.rankings || []).length;
         const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
         const cur = typeof this.gameState.leaderboardPage === 'number' ? this.gameState.leaderboardPage : 0;

--- a/src/ranking/RankingService.js
+++ b/src/ranking/RankingService.js
@@ -1,4 +1,3 @@
-import { MAX_RANKINGS } from "./firebase-config.js";
 function _validateEntry(e) {
   return e && typeof e.time === "number" && typeof e.name === "string";
 }
@@ -11,7 +10,7 @@ function _sanitizeName(raw) {
   );
 }
 function _sortAndTrim(entries) {
-  return [...entries].sort((a, b) => a.time - b.time).slice(0, MAX_RANKINGS);
+  return [...entries].sort((a, b) => a.time - b.time);
 }
 export class RankingService {
   constructor(repository) {

--- a/src/ranking/firebase-config.js
+++ b/src/ranking/firebase-config.js
@@ -9,4 +9,4 @@ export const firebaseConfig = {
 };
 export const RANKINGS_COLLECTION = "rankings";
 export const RANKINGS_DOC = "leaderboard";
-export const MAX_RANKINGS = 10;
+

--- a/src/rendering/screen-renderer.js
+++ b/src/rendering/screen-renderer.js
@@ -644,10 +644,6 @@ function drawLeaderboardScreen(ctx, w, h, gameState) {
   const fade = Math.min(1, age / 0.5);
   const rankings = (gameState && gameState.rankings) || [];
   const page = (gameState && typeof gameState.leaderboardPage === "number") ? gameState.leaderboardPage : 0;
-  const effectivePageSize = isPortrait ? 6 : 10;
-  const totalPages = Math.max(1, Math.ceil((rankings.length || 0) / effectivePageSize));
-  const curPage = Math.max(0, Math.min(page, totalPages - 1));
-
   ctx.save();
   ctx.globalAlpha = fade;
   ctx.fillStyle = R.bg;
@@ -666,29 +662,35 @@ function drawLeaderboardScreen(ctx, w, h, gameState) {
   ctx.lineTo(w - pad, pad + titleSz + 6);
   ctx.stroke();
 
-  
   const ctrlBtnW = Math.min(72, Math.round(w * 0.14));
   const ctrlBtnH = isPortrait ? 24 : 18;
   const gap = 6;
-  
+
   const lineY = pad + titleSz + 6;
   const nextBtnX = w - pad - ctrlBtnW;
   const prevBtnX = nextBtnX - (ctrlBtnW + gap);
   const ctrlBtnY = Math.round(lineY + 6);
-  const showPagingControls = (rankings && rankings.length) > 10;
+
+  // calcula área disponível para a lista
+  const topY = pad + titleSz + ctrlBtnH + 18;
+  const bottomH = 40;
+  const availH = h - topY - bottomH - pad;
+
+  // tamanho de linha e page size calculados pelo espaço real da tela
+  const minRowH = isPortrait ? 22 : 20;
+  const maxRowH = isPortrait ? 44 : 40;
+  const rowH = Math.max(minRowH, Math.min(maxRowH, Math.round(availH / 8)));
+  const effectivePageSize = Math.max(1, Math.floor(availH / (rowH + 4)));
+
+  const totalPages = Math.max(1, Math.ceil((rankings.length || 0) / effectivePageSize));
+  const curPage = Math.max(0, Math.min(page, totalPages - 1));
+
+  const showPagingControls = rankings.length > effectivePageSize;
   if (showPagingControls) {
     drawSmallButton(ctx, prevBtnX, ctrlBtnY, ctrlBtnW, ctrlBtnH, "ANT", false);
     drawSmallButton(ctx, nextBtnX, ctrlBtnY, ctrlBtnW, ctrlBtnH, "PROX", false);
   }
 
-  
-
-  
-  const topY = showPagingControls ? Math.max(pad + titleSz + 18, ctrlBtnY + ctrlBtnH + 6) : (pad + titleSz + 18);
-  const bottomH = 40;
-  const availH = h - topY - bottomH - pad;
-  
-  const rowH = Math.max(20, Math.min(48, availH / effectivePageSize - 4));
   const offset = curPage * effectivePageSize;
   drawRankList(ctx, pad, topY, w - pad * 2, rowH, rankings, effectivePageSize, offset);
 


### PR DESCRIPTION
This pull request updates the leaderboard pagination logic to dynamically calculate the number of entries shown per page based on the available screen space, rather than using a fixed page size. It also removes the previous hard limit on the number of stored rankings and ensures consistency between the logic for determining page size in both the game logic and rendering code.

**Leaderboard Pagination and Rendering Improvements:**

* The calculation for `PAGE_SIZE` in `Game` and `effectivePageSize` in the screen renderer now both use the actual screen dimensions to determine how many leaderboard entries fit per page, making the UI more responsive to different screen sizes. [[1]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcL254-R267) [[2]](diffhunk://#diff-9ef168e76cb49d1d7c8d3c9cedc53a5adf4241a73f6b1c13a3118698fda91133L678-L691)
* The logic for showing paging controls now depends on whether the number of rankings exceeds the dynamically calculated page size, rather than a fixed threshold.

**Ranking Data Handling:**

* The maximum number of stored rankings (`MAX_RANKINGS`) has been removed, allowing all entries to be kept and shown, not just the top 10. [[1]](diffhunk://#diff-bb9e04b6b18eec9c45c60e181c67320f181cc1f72cef6cabf5b440b107d7bf50L12-R12) [[2]](diffhunk://#diff-c271b97d5268cc3d00a33f6ca0e9c841af48ec9a345953060eb412c2838e704eL1) [[3]](diffhunk://#diff-c271b97d5268cc3d00a33f6ca0e9c841af48ec9a345953060eb412c2838e704eL14-R13)

**Code Cleanup and Consistency:**

* Removed unused imports and old fixed-size logic to avoid confusion and ensure the codebase reflects the new dynamic approach. [[1]](diffhunk://#diff-9ef168e76cb49d1d7c8d3c9cedc53a5adf4241a73f6b1c13a3118698fda91133L647-L650) [[2]](diffhunk://#diff-9ef168e76cb49d1d7c8d3c9cedc53a5adf4241a73f6b1c13a3118698fda91133L669)…d on screen dimensions