### PR TITLE
Add Spotify episode link and embed player to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,10 @@
 
       <div class="actions">
         <a id="play-btn" class="btn primary" href="/play/" aria-label="Jogar Apex Type Z">Jogar</a>
-        <a class="btn ghost" href="https://open.spotify.com/" target="_blank" rel="noopener">Ouvir podcast</a>
+        <a id="spotify-link" class="btn ghost" href="https://open.spotify.com/episode/5SRXstwZdXWuUTi51n6bDD" target="_blank" rel="noopener">Ouvir podcast</a>
       </div>
+      <!-- Spotify embed container: landing.js will lazy-load the iframe from data-src -->
+      <div id="spotify-embed" class="spotify-embed" data-src="https://open.spotify.com/embed/episode/5SRXstwZdXWuUTi51n6bDD" aria-label="Podcast do grupo - episódio"></div>
 
       <footer class="foot"><small>UFABC</small></footer>
     </main>

--- a/src/landing.css
+++ b/src/landing.css
@@ -11,6 +11,9 @@ main.hero{min-height:100vh;display:flex;flex-direction:column;align-items:center
 .btn.primary{background:var(--accent);color:#07111a}
 .btn.ghost{background:transparent;border:1px solid rgba(255,255,255,0.06);color:var(--muted)}
 .foot{margin-top:18px;color:var(--muted)}
+/* Spotify embed styles */
+.spotify-embed{width:100%;max-width:660px;margin:18px auto 0;border-radius:12px;overflow:hidden;border:1px solid rgba(255,255,255,0.04);background:linear-gradient(180deg,rgba(255,255,255,0.02),transparent)}
+.spotify-embed iframe{display:block;border:0;width:100%;height:232px}
 
 @media(min-width:700px){
   .hero{padding:44px}

--- a/src/landing.js
+++ b/src/landing.js
@@ -11,6 +11,13 @@ if (playBtn) {
   playBtn.href = import.meta.env.BASE_URL + 'play/';
 }
 
+// Ensure the Spotify link points to the episode URL (keeps HTML and JS consistent)
+const spotifyLink = document.getElementById('spotify-link');
+if (spotifyLink) {
+  // canonical episode URL (without extra querystring params)
+  spotifyLink.href = 'https://open.spotify.com/episode/5SRXstwZdXWuUTi51n6bDD';
+}
+
 
 document.addEventListener('DOMContentLoaded', () => {
   const el = document.getElementById('spotify-embed');


### PR DESCRIPTION
This pull request adds a Spotify podcast episode embed to the landing page and ensures consistent linking to the episode. The main changes include updating the podcast link, introducing a lazy-loaded embed container, adding styles for the embed, and synchronizing the episode URL in both HTML and JavaScript.

**Spotify podcast integration:**

* Updated the podcast button (`#spotify-link`) to point directly to a specific Spotify episode URL and added an accessible label. (`index.html`, `src/landing.js`) [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L22-R25) [[2]](diffhunk://#diff-9c6d1e15e2d3ef7c31ae945242e56e903cb43b55d78502fb63985a9f4cff2325R14-R20)
* Added a new `#spotify-embed` container to the landing page, which is set up for lazy-loading the Spotify iframe. (`index.html`)
* Introduced CSS styles for the `.spotify-embed` container and its iframe to ensure proper appearance and responsiveness. (`src/landing.css`)

**Code consistency:**

* Synchronized the Spotify episode URL between the HTML and JavaScript to prevent mismatches and ensure the link always points to the correct episode. (`src/landing.js`)