### PR TITLE
Improve alignment of main CTA button and update gyroscope warning

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -24,6 +24,7 @@ import {
 } from "../constants/index.js";
 import { clamp } from "../utils/math.js";
 import {
+  isMobile,
   requiresOrientationPermission,
   requiresMotionPermission,
 } from "../utils/platform.js";
@@ -64,6 +65,10 @@ class Game {
     this._screenChangeTime = Date.now();
     this._gyroscopeWarning = false;
     this._iosPermissionStatus = requiresOrientationPermission ? "prompt" : null;
+    // If permission is granted as a direct result of the overlay tap, we should
+    // NOT auto-start the race by replaying the tap. This flag prevents a
+    // single immediate auto-start; user must press START again.
+    this._justGrantedGyroPermission = false;
     // Load persisted settings
     try {
       this._settingsDifficulty = parseInt(localStorage.getItem("cfg_difficulty") ?? "1", 10);
@@ -250,7 +255,6 @@ class Game {
       track: this.track,
       callbacks: {
         advance: () => this._advanceIntroScreen(),
-        startRace: () => this._startRace(),
         retry: () => this.reset(SCREENS.START),
         focusNameInput: () => this._nameInput.focus(),
         onRaceEnter: () => {},
@@ -302,6 +306,74 @@ class Game {
           this._setScreen(target);
         },
         requestGyroPermission: () => this.input.requestOrientationPermission(),
+        startRace: () => {
+          // Enforce gyro permission / availability on mobile devices.
+          // Do NOT auto-start after permission is granted — user must press START again.
+          try {
+            if (!isMobile) {
+              this._startRace();
+              return;
+            }
+
+            // If platform requires an explicit permission API (iOS), only allow start
+            // when permission status is granted.
+            if (requiresMotionPermission || requiresOrientationPermission) {
+              if (this._iosPermissionStatus === "granted") {
+                // If permission was just granted as part of the tap that
+                // triggered the permission flow, do NOT auto-start — require
+                // the user to press START again. Clear the transient flag and
+                // return.
+                if (this._justGrantedGyroPermission) {
+                  this._justGrantedGyroPermission = false;
+                  this._gyroscopeWarning = false;
+                  if (this.gameState) this.gameState.gyroscopeWarning = false;
+                  return;
+                }
+                this._startRace();
+                return;
+              }
+
+              // Trigger the permission prompt (this is a user gesture) but do not
+              // automatically start the race after the user responds — they must
+              // press START again. The InputController will update iosPermissionStatus
+              // via the onGyroPermissionChange handler.
+              try {
+                this.input.requestOrientationPermission();
+              } catch (e) {
+                // best-effort: mark warning so UI informs the user
+                this._gyroscopeWarning = true;
+                if (this.gameState) this.gameState.gyroscopeWarning = true;
+              }
+              return;
+            }
+
+            // For platforms that don't require an explicit permission API (Android/others)
+            // require the gyroscope to have emitted at least one event (indicated by
+            // InputController._gyroscopeActive) before allowing the race to start.
+            if (this.input && this.input._gyroscopeActive) {
+              this._startRace();
+              return;
+            }
+
+            // Attempt to bind motion/orientation listeners so the sensor may activate,
+            // but do not start automatically — show the generic warning and require
+            // the user to press START again after the sensor becomes available.
+            if (this.input) {
+              try {
+                if (requiresMotionPermission && this.input._bindDeviceMotionEvent)
+                  this.input._bindDeviceMotionEvent();
+                else if (this.input._bindDeviceOrientationEvent)
+                  this.input._bindDeviceOrientationEvent();
+              } catch (e) {}
+            }
+            this._gyroscopeWarning = true;
+            if (this.gameState) this.gameState.gyroscopeWarning = true;
+          } catch (err) {
+            // defensive fallback: do not start the race
+            this._gyroscopeWarning = true;
+            if (this.gameState) this.gameState.gyroscopeWarning = true;
+          }
+        },
         setDifficulty: (index) => {
           this._settingsDifficulty = index;
           this._applyDifficultyPreset(index);
@@ -401,6 +473,7 @@ class Game {
     if (requiresMotionPermission) {
       DeviceMotionEvent.requestPermission()
         .then((state) => {
+          if (state === "granted") this._justGrantedGyroPermission = true;
           const status = state === "granted" ? "granted" : "denied";
           this._iosPermissionStatus = status;
           if (this.gameState) this.gameState.iosPermissionStatus = status;
@@ -415,6 +488,7 @@ class Game {
     } else if (requiresOrientationPermission) {
       DeviceOrientationEvent.requestPermission()
         .then((state) => {
+          if (state === "granted") this._justGrantedGyroPermission = true;
           const status = state === "granted" ? "granted" : "denied";
           this._iosPermissionStatus = status;
           if (this.gameState) this.gameState.iosPermissionStatus = status;

--- a/src/menu/states/StartMenuState.js
+++ b/src/menu/states/StartMenuState.js
@@ -30,7 +30,8 @@ export class StartMenuState extends GameState {
     this._lastW = w;
     this._lastH = h;
     const isPortrait = h > w;
-    const btnStartY = isPortrait ? h * 0.44 : h * 0.62;
+    // Nudge the main CTA slightly upward (um pouquinho)
+    const btnStartY = isPortrait ? h * 0.42 : h * 0.60;
     const btnH = Math.max(44, Math.round(h * 0.075));
     this._ctaBtn.setRect(0, btnStartY, w, btnH);
     this._ctaBtn.renderPressOverlay(ctx);
@@ -117,9 +118,13 @@ export class StartMenuState extends GameState {
         const sz = Math.max(11, Math.min(15, availW * 0.034));
         const btnH = sz + 16;
         const btnW = availW * 0.9;
+        // Keep the gyro/button alignment in sync with the renderer: place it
+        // just below the CTA. Use the same gap used in the renderer.
+        const btnGap = Math.max(10, Math.round(h * 0.018));
+        const gyroY = Math.round(btnStartY + btnH + btnGap + 4);
         this._gyroBtn.setRect(
           tx,
-          Math.round(h * 0.54),
+          gyroY,
           Math.round(btnW),
           Math.round(btnH),
         );

--- a/src/rendering/screen-renderer.js
+++ b/src/rendering/screen-renderer.js
@@ -453,7 +453,8 @@ function drawStartScreen(ctx, w, h, gameState, track) {
     ctx.moveTo(pad, h * 0.14 + titleSz * 2.7);
     ctx.lineTo(w - pad, h * 0.14 + titleSz * 2.7);
     ctx.stroke();
-    const btnStartY = h * 0.44;
+    // Nudge the main CTA slightly upward so it sits a bit higher on the screen
+    const btnStartY = h * 0.42;
     drawButton(ctx, pad, btnStartY, btnW, btnH, "INICIAR CORRIDA", blink);
     if (gameState && gameState.iosPermissionStatus === "prompt") {
       drawIOSPermissionButton(
@@ -499,7 +500,8 @@ function drawStartScreen(ctx, w, h, gameState, track) {
     const subSz = csz(w, 0.02, 10, 13);
     ctx.font = `700 ${subSz}px ${R.font}`;
     ctx.fillText("TIME ATTACK", pad, h * 0.28 + titleSz * 2.35);
-    const btnStartY = h * 0.62;
+    // Nudge the main CTA slightly upward in landscape as well
+    const btnStartY = h * 0.60;
     drawButton(
       ctx,
       pad,

--- a/src/rendering/screen-renderer.js
+++ b/src/rendering/screen-renderer.js
@@ -321,7 +321,8 @@ function drawGyroscopeWarning(ctx, x, y, w) {
   ctx.textAlign = "left";
   ctx.fillStyle = R.textHeader;
   ctx.font = `700 ${sz}px ${R.font}`;
-  ctx.fillText("[!] USE SAFARI NO iOS PARA GIROSCOPIO", x, y);
+  // Mensagem genérica instruindo o usuário a ativar/permitir o sensor de movimento
+  ctx.fillText("[!] ATIVE O SENSOR DE MOVIMENTO / GIROSCÓPIO NO NAVEGADOR", x, y);
   ctx.restore();
 }
 // Draws a horizontal segmented selector (radio-button style).


### PR DESCRIPTION
This pull request improves the user experience around starting a race on mobile devices, especially on iOS where explicit motion/orientation permissions are required. It prevents the race from auto-starting immediately after the user grants gyroscope permission, making sure the user must press "START" again. The pull request also refines the positioning and messaging of UI elements for better clarity and alignment.

**Mobile Permission Handling and Race Start Logic:**

- Added logic in `Game` to prevent the race from auto-starting immediately after gyroscope permission is granted; instead, the user must press "START" again. This is managed via a new `_justGrantedGyroPermission` flag and updated `startRace` callback logic. [[1]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcR68-R71) [[2]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcL253) [[3]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcR309-R376) [[4]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcR476) [[5]](diffhunk://#diff-62051d1a3fa3df6ee54623ea714cee18512e052c5cefe025613438de3ab775fcR491)
- Improved detection and handling of mobile platforms by importing and using the `isMobile` utility.

**UI/UX Improvements:**

- Adjusted the main call-to-action ("INICIAR CORRIDA") button position to sit slightly higher on both portrait and landscape layouts for better visual alignment. [[1]](diffhunk://#diff-162b858a5f99e5ae5f694bf8d703f4cfcbb43edae4e9a21a29dece516c2d5810L33-R34) [[2]](diffhunk://#diff-9ef168e76cb49d1d7c8d3c9cedc53a5adf4241a73f6b1c13a3118698fda91133L456-R458) [[3]](diffhunk://#diff-9ef168e76cb49d1d7c8d3c9cedc53a5adf4241a73f6b1c13a3118698fda91133L502-R505)
- Synced the gyroscope permission button's position with the main CTA, ensuring consistent spacing and alignment in the menu state.

**User Messaging:**

- Updated the gyroscope warning message to a more generic and instructive text, telling users to enable the motion/gyroscope sensor in their browser, rather than referencing Safari/iOS specifically.