### PR TITLE
Refactor skid layer handling for improved performance

### DIFF
--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -27,7 +27,6 @@ import {
   ZOOM_MIN,
   ZOOM_LERP,
   BRAKE_ZOOM_BONUS,
-  SKID_LAYER_DPR,
   SKID_SLIP_THRESHOLD,
   SKID_LATERAL_VEL_THRESHOLD,
 } from "../constants/index.js";
@@ -157,12 +156,9 @@ class Renderer {
     this._shake.y = Math.round(this._shake.y);
     ctx.imageSmoothingEnabled = false; 
     
-    const dpr = SKID_LAYER_DPR;
     if (!this._skidLayer) {
-      this._skidLayer = createSkidLayer(metrics.width, metrics.height, dpr);
-      
-      this._skidLayer.resize(metrics.width, metrics.height, dpr);
-    } else this._skidLayer.resize(metrics.width, metrics.height, dpr);
+      this._skidLayer = createSkidLayer();
+    }
 
     
     // Prefer reuse of provided currentTrackPoint (often cached on gameState),
@@ -184,20 +180,23 @@ class Renderer {
 
     
     const carDrawPos = computeCarDrawPosition(gameState, metrics.width, metrics.height);
-    const prevCar = this._prevCarDraw || null;
 
-    
     const slipVal = gameState.currentSlip || 0;
     const latV = Math.abs(gameState.lateralVelocity || 0);
-    if (prevCar && this._skidLayer) {
+    if (this._prevCarZ !== undefined && this._skidLayer) {
       const shouldSkid = slipVal >= SKID_SLIP_THRESHOLD || latV >= SKID_LATERAL_VEL_THRESHOLD;
       if (shouldSkid) {
         const intensity = Math.min(1, Math.max(slipVal, latV / 20));
         const color = gameState.aeroMode === AERO_MODES.X ? 'rgba(30,30,30,0.9)' : 'rgba(60,60,60,0.65)';
-        this._skidLayer.addSkid(prevCar.drawX, prevCar.drawY, carDrawPos.drawX, carDrawPos.drawY, intensity, color);
+        this._skidLayer.addSkid(
+          this._prevCarZ, this._prevCarLat,
+          gameState.currentZ, gameState.lateralOffset || 0,
+          intensity, color,
+        );
       }
     }
-    this._prevCarDraw = carDrawPos;
+    this._prevCarZ = gameState.currentZ;
+    this._prevCarLat = gameState.lateralOffset || 0;
 
     
     ctx.save();
@@ -214,7 +213,7 @@ class Renderer {
     drawTrack(ctx, gameState, track, metrics, roundedCameraX, this._renderCaches);
     
     if (this._skidLayer) {
-      this._skidLayer.drawTo(ctx);
+      this._skidLayer.drawTo(ctx, gameState, track, metrics, roundedCameraX);
     }
     drawObstacles(ctx, gameState, track, metrics);
     drawRivals(ctx, gameState, track, metrics);

--- a/src/rendering/skid-layer.js
+++ b/src/rendering/skid-layer.js
@@ -1,78 +1,123 @@
+import { HALF_RATIO, LATERAL_RENDER_SCALE } from "../constants/index.js";
 
+// Maximum number of segments kept in the ring buffer.
+// At 60fps with continuous skidding this covers ~10 seconds.
+const MAX_SEGMENTS = 600;
 
-function createSkidLayer(width, height, dpr = 1) {
-  let canvas = null;
-  let ctx = null;
-  let w = 0;
-  let h = 0;
-  let _dpr = dpr;
+// How many world-Z units behind the car we keep (roughly 1.5 lap-lengths worth
+// of visible history). Segments older than this are evicted on insert.
+const MAX_Z_AGE = 8000;
 
-  function _ensure(wReq, hReq, dprReq) {
-    if (canvas && w === wReq && h === hReq && _dpr === dprReq) return;
-    w = wReq;
-    h = hReq;
-    _dpr = dprReq;
-    if (typeof OffscreenCanvas !== 'undefined') {
-      canvas = new OffscreenCanvas(Math.max(1, Math.round(w * _dpr)), Math.max(1, Math.round(h * _dpr)));
-      ctx = canvas.getContext('2d');
-    } else {
-      canvas = document.createElement('canvas');
-      canvas.width = Math.max(1, Math.round(w * _dpr));
-      canvas.height = Math.max(1, Math.round(h * _dpr));
-      ctx = canvas.getContext('2d');
-    }
-    ctx.setTransform(_dpr, 0, 0, _dpr, 0, 0);
-    
-    ctx.clearRect(0, 0, w, h);
+/**
+ * World-space skid mark layer.
+ *
+ * Instead of drawing to a fixed-pixel offscreen canvas, we store each skid
+ * segment as a pair of world-space points {z, lateralOffset}. Every frame we
+ * re-project only the visible segments onto the main canvas using the same
+ * pseudo-3D formula used by the track renderer:
+ *
+ *   screenY = carY - (worldZ - currentZ)
+ *   screenX = width*0.5 + (track.getTrackPoint(worldZ).x - cameraX)
+ *             + lateralOffset * LATERAL_RENDER_SCALE
+ *
+ * This makes the marks "scroll" correctly with the road surface.
+ */
+function createSkidLayer() {
+  // Ring buffer of segments
+  const _segs = new Array(MAX_SEGMENTS);
+  let _head = 0; // next write index
+  let _count = 0;
+
+  /**
+   * Record a new skid segment between two world-space positions.
+   *
+   * @param {number} z1        - world Z of previous car position
+   * @param {number} lat1      - lateralOffset of previous car position
+   * @param {number} z2        - world Z of current car position
+   * @param {number} lat2      - lateralOffset of current car position
+   * @param {number} intensity - 0..1
+   * @param {string} color     - CSS color string
+   */
+  function addSkid(z1, lat1, z2, lat2, intensity = 1, color = 'rgba(20,20,20,0.9)') {
+    _segs[_head] = { z1, lat1, z2, lat2, intensity, color };
+    _head = (_head + 1) % MAX_SEGMENTS;
+    if (_count < MAX_SEGMENTS) _count++;
   }
 
-  function resize(wReq, hReq, dprReq = 1) {
-    _ensure(wReq, hReq, dprReq);
-  }
+  /**
+   * Draw all visible segments onto the target canvas context.
+   * Must be called inside the same transform context as drawTrack.
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {object} gameState  - needs currentZ, lateralOffset
+   * @param {object} track      - needs getTrackPoint(z)
+   * @param {object} metrics    - needs width, height, carY
+   * @param {number} cameraX    - rounded camera X (same value passed to drawTrack)
+   */
+  function drawTo(ctx, gameState, track, metrics, cameraX) {
+    if (_count === 0) return;
 
-  
-  function addSkid(x1, y1, x2, y2, intensity = 1, color = 'rgba(20,20,20,0.9)') {
-    if (!ctx) return;
+    const { width, carY } = metrics;
+    const currentZ = gameState.currentZ || 0;
+    const halfW = width * HALF_RATIO;
+
+    // Visible Z range: from just behind the car to the horizon line
+    const zMin = currentZ - carY; // anything behind carY rows is off-screen
+    const zMax = currentZ + carY; // horizon is carY pixels above the car row
+
     ctx.save();
     ctx.lineCap = 'round';
-    ctx.strokeStyle = color;
-    ctx.globalAlpha = Math.max(0.12, Math.min(1, intensity * 0.9));
-    ctx.lineWidth = Math.max(1, Math.min(6, 2 + intensity * 4));
-    ctx.beginPath();
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
-    ctx.stroke();
+
+    for (let i = 0; i < _count; i++) {
+      const idx = (_head - 1 - i + MAX_SEGMENTS) % MAX_SEGMENTS;
+      const s = _segs[idx];
+      if (!s) continue;
+
+      // Quick age eviction — skip very old segments
+      if (s.z2 < currentZ - MAX_Z_AGE) continue;
+
+      // Both endpoints must be at least partially in the visible Z band
+      const inView1 = s.z1 >= zMin && s.z1 <= zMax;
+      const inView2 = s.z2 >= zMin && s.z2 <= zMax;
+      if (!inView1 && !inView2) continue;
+
+      // Project endpoint 1
+      const tp1 = track.getTrackPoint(s.z1);
+      const sx1 = halfW + (tp1.x - cameraX) + s.lat1 * LATERAL_RENDER_SCALE;
+      const sy1 = carY - (s.z1 - currentZ);
+
+      // Project endpoint 2
+      const tp2 = track.getTrackPoint(s.z2);
+      const sx2 = halfW + (tp2.x - cameraX) + s.lat2 * LATERAL_RENDER_SCALE;
+      const sy2 = carY - (s.z2 - currentZ);
+
+      // Increase the minimum alpha so skid marks remain visible in gentle
+      // slides. Also allow slightly thicker marks for higher intensity.
+      ctx.globalAlpha = Math.max(0.30, Math.min(1, s.intensity * 1.0));
+      ctx.lineWidth = Math.max(1, Math.min(8, 2 + s.intensity * 5));
+      ctx.strokeStyle = s.color;
+      ctx.beginPath();
+      ctx.moveTo(sx1, sy1);
+      ctx.lineTo(sx2, sy2);
+      ctx.stroke();
+    }
+
     ctx.restore();
   }
 
-  function drawTo(targetCtx) {
-    if (!canvas) return;
-    
-    try {
-      targetCtx.drawImage(canvas, 0, 0, canvas.width / _dpr, canvas.height / _dpr);
-    } catch (e) {
-      
-      if (canvas instanceof OffscreenCanvas && canvas.convertToBlob) {
-        canvas.convertToBlob().then((b) => {
-          const img = new Image();
-          img.onload = () => targetCtx.drawImage(img, 0, 0);
-          img.src = URL.createObjectURL(b);
-        });
-      }
-    }
+  function clear() {
+    _head = 0;
+    _count = 0;
   }
 
-  function clear() {
-    if (!ctx) return;
-    ctx.clearRect(0, 0, w, h);
-  }
+  // resize is a no-op — world-space layer has no canvas to resize
+  function resize() {}
 
   return {
     resize,
     addSkid,
     drawTo,
     clear,
-    _internalCanvas: () => canvas,
   };
 }
 

--- a/src/systems/input.js
+++ b/src/systems/input.js
@@ -112,15 +112,14 @@ class InputController {
         0;
       let raw;
       if (screenAngle === 90) {
-        // Landscape left: beta maps to lateral tilt; negate for correct dir
-        raw = isAndroid ? e.beta : -e.beta;
+        // Landscape left: beta maps to lateral tilt
+        raw = -e.beta;
       } else if (screenAngle === -90 || screenAngle === 270) {
         // Landscape right
-        raw = isAndroid ? -e.beta : e.beta;
+        raw = e.beta;
       } else {
-        // Portrait: gamma is lateral tilt.
-        // Android: positive gamma = tilt right (correct, no negation needed).
-        // iOS:     positive gamma = tilt right as well, same convention.
+        // Portrait: gamma is lateral tilt, W3C convention is consistent
+        // across Android (including MIUI/Xiaomi) and iOS.
         raw = e.gamma;
       }
       if (raw === null || raw === undefined) return;
@@ -358,6 +357,12 @@ class InputController {
     if (!requiresMotionPermission && !requiresOrientationPermission) {
       if (isIOSWithoutPermission) {
         this.handlers.onGyroscopeUnavailable?.();
+      } else if (isAndroid && browserSupportsDeviceOrientation) {
+        // On Android, deviceorientation (e.gamma) follows the W3C standard
+        // consistently across manufacturers. devicemotion (ag.x) has
+        // inconsistent axis conventions between OEMs (e.g. Xiaomi MIUI vs
+        // stock Android), so we prefer orientation on Android.
+        this._bindDeviceOrientationEvent();
       } else if (browserSupportsDeviceMotion) {
         this._bindDeviceMotionEvent();
       } else if (browserSupportsDeviceOrientation) {


### PR DESCRIPTION
This pull request refactors the skid mark rendering system to use a world-space approach and improves device orientation handling for input. The most significant changes are a complete rewrite of the `skid-layer` logic to store and render skids in world coordinates, resulting in more accurate and persistent marks, and a simplification of device orientation code to follow the W3C standard consistently across platforms.

**Rendering and Skid Layer Refactor:**
- The `skid-layer` is now implemented as a world-space ring buffer of segments, rather than drawing directly to a fixed-size offscreen canvas. Skid marks are projected onto the screen each frame using the same pseudo-3D logic as the track, ensuring they scroll and persist correctly with the road. The new implementation also includes segment aging and visibility logic for performance and realism. (`src/rendering/skid-layer.js`)
- The renderer is updated to use the new `skid-layer` interface: it no longer passes dimensions or device pixel ratio, and it records skid marks using world-space positions (`currentZ`, `lateralOffset`) instead of screen coordinates. (`src/rendering/renderer.js`) [[1]](diffhunk://#diff-74b7eea251c0b6547966eb5ce845d932508c39e9fff30d9813019c676c82584fL30) [[2]](diffhunk://#diff-74b7eea251c0b6547966eb5ce845d932508c39e9fff30d9813019c676c82584fL160-R161) [[3]](diffhunk://#diff-74b7eea251c0b6547966eb5ce845d932508c39e9fff30d9813019c676c82584fL187-R199) [[4]](diffhunk://#diff-74b7eea251c0b6547966eb5ce845d932508c39e9fff30d9813019c676c82584fL217-R216)

**Device Orientation Input Improvements:**
- The input controller now consistently interprets device orientation events according to the W3C standard for both Android and iOS, removing old platform-specific negations and comments. This fixes inconsistencies, especially on Android devices. (`src/systems/input.js`)
- On Android devices, device orientation events (`deviceorientation`) are now preferred over device motion events (`devicemotion`) due to more consistent axis conventions across manufacturers. (`src/systems/input.js`)…by removing unnecessary parameters